### PR TITLE
Adding mechanism to rate the app on the AppStore

### DIFF
--- a/RaceSync.xcodeproj/project.pbxproj
+++ b/RaceSync.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		00463F577FF49FF13F8A871B /* Pods_RaceSyncAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D073602CBE253F96567B3B54 /* Pods_RaceSyncAPI.framework */; };
 		460A0880363895A247C9C23A /* Pods_RaceSyncTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53D65741DB402E1BEAF04DE6 /* Pods_RaceSyncTests.framework */; };
 		4F00E06424292C9A001DCFC4 /* ChapterUserTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F00E06324292C9A001DCFC4 /* ChapterUserTableViewCell.swift */; };
+		4F00E072242932D7001DCFC4 /* RateMe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F00E071242932D7001DCFC4 /* RateMe.swift */; };
+		4F00E075242932F2001DCFC4 /* RateMeDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F00E073242932F2001DCFC4 /* RateMeDefaults.swift */; };
+		4F00E076242932F2001DCFC4 /* RateMeConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F00E074242932F2001DCFC4 /* RateMeConstants.swift */; };
 		4F0B613C238528C300930D91 /* PasteboardLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0B613B238528C300930D91 /* PasteboardLabel.swift */; };
 		4F0B613F2385DA8F00930D91 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0B613E2385DA8F00930D91 /* UIImage+Extensions.swift */; };
 		4F0B61432385EEFF00930D91 /* ViewModelHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0B61422385EEFF00930D91 /* ViewModelHelper.swift */; };
@@ -218,6 +221,9 @@
 		39172015E1CE1AD9586A8B50 /* Pods-RaceSyncAPITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RaceSyncAPITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-RaceSyncAPITests/Pods-RaceSyncAPITests.release.xcconfig"; sourceTree = "<group>"; };
 		40DB5CAFF0B302311BAF739B /* Pods-RaceSyncAPI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RaceSyncAPI.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RaceSyncAPI/Pods-RaceSyncAPI.debug.xcconfig"; sourceTree = "<group>"; };
 		4F00E06324292C9A001DCFC4 /* ChapterUserTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterUserTableViewCell.swift; sourceTree = "<group>"; };
+		4F00E071242932D7001DCFC4 /* RateMe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RateMe.swift; sourceTree = "<group>"; };
+		4F00E073242932F2001DCFC4 /* RateMeDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RateMeDefaults.swift; sourceTree = "<group>"; };
+		4F00E074242932F2001DCFC4 /* RateMeConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RateMeConstants.swift; sourceTree = "<group>"; };
 		4F0B613B238528C300930D91 /* PasteboardLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardLabel.swift; sourceTree = "<group>"; };
 		4F0B613E2385DA8F00930D91 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
 		4F0B61422385EEFF00930D91 /* ViewModelHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelHelper.swift; sourceTree = "<group>"; };
@@ -419,6 +425,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4F00E065242930B3001DCFC4 /* RateMe */ = {
+			isa = PBXGroup;
+			children = (
+				4F00E071242932D7001DCFC4 /* RateMe.swift */,
+				4F00E074242932F2001DCFC4 /* RateMeConstants.swift */,
+				4F00E073242932F2001DCFC4 /* RateMeDefaults.swift */,
+			);
+			path = RateMe;
+			sourceTree = "<group>";
+		};
 		4F0B613D2385DA7900930D91 /* UI Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -599,6 +615,7 @@
 				4FA1FC8A23D6D7C0006D4704 /* ApplicationControl.swift */,
 				4F9DB7B423D6BAC200570483 /* CrashCatcher.swift */,
 				4FEADB732416B3D400F82F0D /* EventCatcher.swift */,
+				4F00E065242930B3001DCFC4 /* RateMe */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -1115,6 +1132,7 @@
 			files = (
 				4F3D641123FE664A00DE6DF2 /* TextFieldViewController.swift in Sources */,
 				4FC5025A2428710D0088320B /* RaceTabbable.swift in Sources */,
+				4F00E072242932D7001DCFC4 /* RateMe.swift in Sources */,
 				4FE490F223A4725D0008C38D /* RaceHeaderView.swift in Sources */,
 				4FD4E1D1237F9DC8008816B3 /* SearchViewController.swift in Sources */,
 				4F8668F423860900005E310A /* UniversalConstants.swift in Sources */,
@@ -1133,6 +1151,7 @@
 				4FEE0E182414255D00A7BABF /* SettingsController.swift in Sources */,
 				4FA1AB4323CAF803007CF389 /* AircraftPickerController.swift in Sources */,
 				4F68BE6D2399DBCF009D44F7 /* UIViewController+Lookup.swift in Sources */,
+				4F00E075242932F2001DCFC4 /* RateMeDefaults.swift in Sources */,
 				4FD4E1E12380AC37008816B3 /* RaceResultsViewController.swift in Sources */,
 				4F3D640F23FC65F700DE6DF2 /* PickerViewController.swift in Sources */,
 				4F1342482360B67D00A9DBDE /* AppDelegate.swift in Sources */,
@@ -1198,6 +1217,7 @@
 				4F8175A32411C39C00685F83 /* RaceListController.swift in Sources */,
 				4FA26835237A80B9008970AC /* ActionButton.swift in Sources */,
 				4F00E06424292C9A001DCFC4 /* ChapterUserTableViewCell.swift in Sources */,
+				4F00E076242932F2001DCFC4 /* RateMeConstants.swift in Sources */,
 				4F9DB7B023D618D100570483 /* UISegmentedControl+Extensions.swift in Sources */,
 				4F5C1E45238D1BD200D756EB /* PasteboardButton.swift in Sources */,
 				4FD53FB323A0E9B700158206 /* AvatarImageView.swift in Sources */,

--- a/RaceSync/Resources/StringConstants.swift
+++ b/RaceSync/Resources/StringConstants.swift
@@ -10,6 +10,9 @@ import Foundation
 
 public class StringConstants {
     public static let Copyright = "Copyright © 2020 MultiGP Inc."
+    public static let ApplicationID = "1491110680"
+    public static let GoogleAnalyticsID = "217966259"
+    public static let SentryClientDSN = "https://4dbd7fdde60b4c828846d94fecc814c1@sentry.io/3036524"
 }
 
 

--- a/RaceSync/Tools/CrashCatcher.swift
+++ b/RaceSync/Tools/CrashCatcher.swift
@@ -15,7 +15,7 @@ class CrashCatcher {
     static func configure() {
         // Create a Sentry client and start crash handler
         do {
-            Client.shared = try Client(dsn: "https://4dbd7fdde60b4c828846d94fecc814c1@sentry.io/3036524")
+            Client.shared = try Client(dsn: StringConstants.SentryClientDSN)
             try Client.shared?.startCrashHandler()
         } catch let error {
             Clog.log("\(error)", andLevel: .error)

--- a/RaceSync/Tools/EventCatcher.swift
+++ b/RaceSync/Tools/EventCatcher.swift
@@ -11,15 +11,22 @@ import RaceSyncAPI
 
 class EventCatcher {
 
-    static let showLogs: Bool = false
-
     static func configure() {
+        configureAnalytics()
+        configureRater()
+    }
+
+    // MARK: - Analytics
+
+    fileprivate static let showLogs: Bool = true
+
+    fileprivate static func configureAnalytics() {
         guard let gai = GAI.sharedInstance() else {
             Clog.log("Google Analytics not configured correctly")
             return
         }
-        
-        gai.tracker(withTrackingId: "224684788")
+
+        gai.tracker(withTrackingId: StringConstants.GoogleAnalyticsID)
         // Optional: automatically report uncaught exceptions.
         gai.trackUncaughtExceptions = true
 
@@ -44,5 +51,30 @@ class EventCatcher {
         gai?.dispatch()
 
         Clog.log("Tracking Screen with name : \(name)")
+    }
+
+    // MARK: - AppStore Rater
+
+    fileprivate static func configureRater() {
+        let rater = RateMe.sharedInstance
+        rater.debug = false
+        rater.showPreview = false
+
+        // Interval configs
+        rater.usesUntilPrompt = 10
+        rater.daysUntilPrompt = 5
+        rater.eventsUntilPrompt = 3
+        rater.daysBeforeReminding = 7
+        rater.shouldPromptIfRated = true
+        rater.showNeverRemindButton = false
+        rater.shouldPrompAtLaunch = false
+
+        // Content configs
+        rater.appId = StringConstants.ApplicationID
+        rater.applicationName = Bundle.main.applicationName
+        rater.reviewTitle = "Rate \(Bundle.main.applicationName)"
+        rater.reviewMessage = "Please take a moment to rate and review the app on the App Store.\n\nThank you for your support!"
+        rater.rateButtonTitle = "Rate Now"
+        rater.remindButtonTitle = "Maybe Later"
     }
 }

--- a/RaceSync/Tools/RateMe/RateMe.swift
+++ b/RaceSync/Tools/RateMe/RateMe.swift
@@ -1,0 +1,455 @@
+//
+//  RateMe.swift
+//  RaceSync
+//
+//  Created by Ignacio Romero Zurbuchen on 2020-03-23.
+//  Copyright © 2020 MultiGP Inc. All rights reserved.
+//
+//  Adaptation of SwiftlyRater
+//  Created by Gianluca Di Maggio on 1/2/17.
+//  Copyright © 2017 dima. All rights reserved.
+//
+
+import Foundation
+
+@objc public protocol RateMeProtocol {
+    func rateMeDidShowPrompt() -> Void
+    func rateMeDidTapRate() -> Void
+    func rateMeDidTapDecline() -> Void
+    func rateMeDidTapRemind() -> Void
+}
+
+/// A simple and lightweight Review Manager for iOS, written in Swift
+public class RateMe: NSObject {
+
+    public static var sharedInstance = RateMe()
+    public var appId: String?
+    public weak var delegate: RateMeProtocol?
+
+    // MARK: - Public methods
+
+    /*
+     * Calling this function will show the Rater alert if all
+     * the following conditions are satisfied:
+     * 1) Network is available
+     * 2) Users has not declined to rate this version
+     * 3) Users has not rated this version already
+     * 4) No version has been rated OR a new version will ask for a review anyhow
+     * 5) Remind was never tapped OR it was tapped and enough days have gone by since then
+     * 6) Enough signiicants Events have happened OR enough Uses
+     */
+    public func showPromptIfNeeded() {
+        guard !self.didDeclineToRate else { // 1
+            self.debugLog("User declined to rate current app version")
+            return
+        }
+
+        guard !self.didRateCurrentVersion else { // 2
+            self.debugLog("Current version has been rated already")
+            return
+        }
+
+        guard !self.didRateAnyVersion || self.shouldPromptIfRated else { // 3
+            self.debugLog("One version rated already, won't ask to rate again")
+            return
+        }
+
+        if let lastReminded = self.lastReminded { // 4
+            guard  let daysElapsed = Calendar.current.dateComponents([.day], from: lastReminded, to: Date()).day,
+                daysElapsed >= self.daysBeforeReminding else {
+                    self.debugLog("Not enough days (\(self.daysBeforeReminding)) since last reminder: \(lastReminded)")
+                    return
+            }
+        }
+
+        guard self.useCount >= self.usesUntilPrompt || self.eventsCount >= self.eventsUntilPrompt else { // 6
+            self.debugLog("Uses \(self.useCount)/\(self.usesUntilPrompt), Events \(self.eventsCount)/\(self.eventsUntilPrompt)")
+            return
+        }
+
+        self.showPrompt()
+    }
+
+    /*
+     * Use this method to inform SR that a significant event has been
+     * performed by the user and increasing the events count.
+     */
+    public func userDidPerformEvent(showPrompt: Bool) {
+        self.eventsCount += 1
+
+        if showPrompt {
+            self.showPromptIfNeeded()
+        }
+    }
+
+    // MARK: - Public State for Rater logic
+
+    /*
+     * Times the app needs to be launched before Rater is shown
+     * Default: 10
+     */
+    public var usesUntilPrompt: Int = RateMeConstants.usesUntilPrompt
+
+    /*
+     * Days the app needs to be used before Rater is shown
+     * Default: 5
+     */
+    public var daysUntilPrompt: Int = RateMeConstants.daysUntilPrompt
+
+    /*
+     * Specific/Custom events that need to happen before Rater is shown
+     * Default: 10
+     */
+    public var eventsUntilPrompt: Int = RateMeConstants.eventsUntilPrompt
+
+    /*
+     * Days before the Rater is shown again
+     * Default: 1
+     */
+    public var daysBeforeReminding: Int = RateMeConstants.daysBeforeReminding
+
+    /*
+     * By default, users will be asked to rate each new verion of the app
+     * regardless of whether they already rated a previous version or not.
+     * By setting this to false, users that have left a review already will
+     * not be asked to leave another review again.
+     */
+    public var shouldPromptIfRated: Bool = true
+
+    /*
+     * By default, the prompt will be shown when the App launches,
+     * i.e. when appDidFinishLaunchingWithOptions returns.
+     * To show the prompt at a different time, set this property
+     * to false and call 'showPromptIfNeeded' when needed.
+     */
+    public var shouldPrompAtLaunch: Bool = true
+
+    /*
+     * By default, the alert only shows two options: Rate Now and Remind Later
+     * By setting this property to true, a third option will be added to the alert,
+     * givin users the change to dismiss the Alert so that it won't show up again
+     * (but only for the current version)
+     */
+    public var showNeverRemindButton = false
+
+    /*
+     * By default, RateMe will use its own localization files.
+     * If you want to provide custom localization, set this property
+     * to true and provide 'SRLocalizable.strings' in your main bundle.
+     */
+    public var useCustomLocalizationFile = false
+
+    // MARK: - Configurable UI elements
+
+    /*
+     * Retrieved by application plist if Nil, can be overwritten
+     */
+    public var applicationName: String? = nil
+
+    /*
+     * Title of the Alert
+     */
+    public var reviewTitle: String = RateMeConstants.reviewTitle
+
+    /*
+     * Content of the Alert
+     */
+    public var reviewMessage: String = RateMeConstants.reviewMessage
+
+    /*
+     * Title of of the Rate button
+     */
+    public var rateButtonTitle: String = RateMeConstants.rateButtonTitle
+
+    /*
+     * Title of the Remind button
+     */
+    public var remindButtonTitle: String = RateMeConstants.remindButtonTitle
+
+    /*
+     * Title of the Never Remind button
+     */
+    public var neverRemindButtonTitle: String = RateMeConstants.neverRemindButtonTitle
+
+    /*
+     * Will enable debug logs
+     */
+    public var debug: Bool = false
+    public var showPreview: Bool = false
+
+    // MARK: - Lifecycle
+
+    override private init() {
+        super.init()
+        setup()
+    }
+
+    private func setup(){
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(self.applicationDidFinishLaunching) ,
+                                               name: UIApplication.didFinishLaunchingNotification, object: nil)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(self.applicationWillResignActive) ,
+                                               name: UIApplication.willResignActiveNotification, object: nil)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(self.applicationWillEnterForeground) ,
+                                               name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Private methods
+
+    @objc private func applicationWillResignActive() {
+        UserDefaults.RateMeDefaults.synchronize()
+    }
+
+    @objc private func applicationWillEnterForeground() {
+        UserDefaults.RateMeDefaults.synchronize()
+    }
+
+    @objc private func applicationDidFinishLaunching() {
+
+        // Check if ever used or version change
+        if self.firstUse == nil || (self.lastVersionUsed != self.currentVersion) {
+            self.resetStateForNewVersion()
+        }
+
+        // Increment use count
+        self.useCount += 1
+
+        let appName = self.applicationName ?? self.applicationNameBundle
+        let versionRated = self.lastVersionRated ?? "N/A"
+        self.debugLog("Name:\(appName), CurrentVersion:\(self.currentVersion), LastRatedVersion:\(versionRated), RatedCurrentVersion:\(self.didRateCurrentVersion), Uses:\(self.useCount), Events:\(self.eventsCount)")
+
+        if self.showPreview {
+            self.showPrompt()
+        } else if self.shouldPrompAtLaunch {
+            self.showPromptIfNeeded()
+        }
+    }
+
+    private func showPrompt() {
+        self.debugLog("Showing Rate prompt")
+
+        // Dynamically create title by swapping in the application name
+        let appName = self.applicationName ?? self.applicationNameBundle
+        let reviewTitle = self.reviewTitle.localized(bundle: self.bundle).replacingOccurrences(of: "%@",
+                                                                                               with: appName,
+                                                                                               options: String.CompareOptions(rawValue: 0),
+                                                                                               range: nil)
+
+        let rateAlert = UIAlertController(title: reviewTitle,
+                                          message: self.reviewMessage.localized(bundle: self.bundle),
+                                          preferredStyle: .alert)
+        let itunesAction = UIAlertAction(title: self.rateButtonTitle.localized(bundle: self.bundle),
+                                         style: .cancel,
+                                         handler: { (action) -> Void in
+                                            guard let appId = self.appId, let url = self.appstoreURL(with: appId) else {
+                                                self.debugLog("Please provide a valid AppId")
+                                                return
+                                            }
+
+                                            UIApplication.shared.open(url, options: [:], completionHandler: { (completed) in
+                                                self.lastVersionRated = self.currentVersion
+                                            })
+                                            self.delegate?.rateMeDidTapRate()
+        })
+
+        let remindAction = UIAlertAction(title: self.remindButtonTitle.localized(bundle: self.bundle),
+                                         style: .default,
+                                         handler: { (action) -> Void in
+                                            self.lastReminded = Date()
+                                            self.delegate?.rateMeDidTapRemind()
+        })
+
+        rateAlert.addAction(remindAction)
+        rateAlert.addAction(itunesAction)
+
+        if self.showNeverRemindButton {
+            rateAlert.addAction(
+                UIAlertAction(title: self.neverRemindButtonTitle.localized(bundle: self.bundle),
+                              style: .default,
+                              handler: { (action) -> Void in
+                                self.didDeclineToRate = true
+                                self.delegate?.rateMeDidTapDecline()
+                })
+            )
+        }
+
+        DispatchQueue.main.async {
+            self.topViewController?.present(rateAlert, animated: true, completion: {
+                self.delegate?.rateMeDidShowPrompt()
+            })
+        }
+    }
+
+    private func appstoreURL(with appId: String) -> URL? {
+        let url = "itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=\(appId)&onlyLatestVersion=true&pageNumber=0&sortOrdering=1&type=Purple+Software"
+        return URL(string: url)
+    }
+
+    // MARK: - Internal State
+
+    private var didDeclineToRate: Bool {
+        set {
+            UserDefaults.RateMeDefaults.set(newValue, forKey: .declinedToRate)
+            UserDefaults.RateMeDefaults.synchronize()
+        }
+        get {
+            return UserDefaults.RateMeDefaults.bool(forKey: .declinedToRate)
+        }
+    }
+
+    private var didRateCurrentVersion: Bool {
+        guard let lastVersionRated = self.lastVersionRated else {
+            return false
+        }
+
+        let result = lastVersionRated.compare(self.currentVersion, options: .numeric, range: nil, locale: nil)
+        return result != ComparisonResult.orderedAscending // Left op. is either same or greater than right op.
+    }
+
+    private var lastVersionRated: String? {
+        set {
+            UserDefaults.RateMeDefaults.set(newValue, forKey: .versionRated)
+            UserDefaults.RateMeDefaults.synchronize()
+        }
+        get {
+            return UserDefaults.RateMeDefaults.string(forKey: .versionRated)
+        }
+    }
+
+    private var didRateAnyVersion: Bool {
+        return (self.lastVersionRated != nil)
+    }
+
+    private var currentVersion: String {
+        let currentVersionShort = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let currentVersionBundle = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as? String
+        return currentVersionShort ?? currentVersionBundle ?? "0.0.0"
+    }
+
+    private var lastVersionUsed: String? {
+        set {
+            UserDefaults.RateMeDefaults.set(newValue, forKey: .lastVersionUsed)
+            UserDefaults.RateMeDefaults.synchronize()
+        }
+        get {
+            return UserDefaults.RateMeDefaults.string(forKey: .lastVersionUsed)
+        }
+    }
+
+    private var lastReminded: Date? {
+        set {
+            UserDefaults.RateMeDefaults.set(newValue?.timeIntervalSince1970, forKey: .lastReminded)
+            UserDefaults.RateMeDefaults.synchronize()
+        }
+        get {
+            return UserDefaults.RateMeDefaults.date(forKey: .lastReminded)
+        }
+    }
+
+    private var firstUse: Date? {
+        set {
+            UserDefaults.RateMeDefaults.set(newValue?.timeIntervalSince1970, forKey: .firstUse)
+            UserDefaults.RateMeDefaults.synchronize()
+        }
+        get {
+            return UserDefaults.RateMeDefaults.date(forKey: .firstUse)
+        }
+    }
+
+    private var useCount: Int {
+        set {
+            UserDefaults.RateMeDefaults.set(newValue, forKey: .usesCount)
+            UserDefaults.RateMeDefaults.synchronize()
+        }
+        get {
+            return UserDefaults.RateMeDefaults.int(forKey: .usesCount)
+        }
+    }
+
+    private var eventsCount: Int {
+        set {
+            UserDefaults.RateMeDefaults.set(newValue, forKey: .eventsCount)
+            UserDefaults.RateMeDefaults.synchronize()
+        }
+        get {
+            return UserDefaults.RateMeDefaults.int(forKey: .eventsCount)
+        }
+    }
+
+    /*
+     * The Alert will automaticall retrieve the App name from 
+     * the bundle if none has been set by the user on initialization
+     */
+    private var applicationNameBundle: String {
+        let applicationNameDisplay = Bundle.main.localizedInfoDictionary?["CFBundleDisplayName"] as? String
+        let applicationNameBundle = Bundle.main.object(forInfoDictionaryKey: kCFBundleNameKey as String) as? String
+        return applicationNameDisplay ?? applicationNameBundle ?? "This App"
+    }
+
+    // MARK: - Helper
+
+    /*
+     * Use RateMe bundle by default, else use host application
+     * bundle if 'self.useCustomLocalizationFile' is set to true
+     */
+    private var bundle: Bundle {
+        if self.useCustomLocalizationFile {
+            return Bundle.main
+        } else {
+            return Bundle(for: type(of: self))
+        }
+    }
+    
+    /*
+     * Set all the usage stats back to the initial value,
+     * i.e. every app updates is de facto treated as a fresh install
+     *
+     */
+    private func resetStateForNewVersion() -> Void {
+        self.useCount = 0
+        self.eventsCount = 0
+        self.didDeclineToRate = false
+        self.firstUse = Date()
+        self.lastReminded = nil
+        self.lastVersionUsed = self.currentVersion
+
+        self.debugLog("New version detected, resetting internal state")
+    }
+
+    private var topViewController: UIViewController? {
+        var topController: UIViewController? = UIApplication.shared.windows.first?.rootViewController
+        var isPresenting = false
+        repeat {
+            if let controller = topController {
+                if let presented = controller.presentedViewController {
+                    isPresenting = true
+                    topController = presented
+                } else {
+                    isPresenting = false
+                }
+            }
+        } while isPresenting
+        return topController
+    }
+    
+    private func debugLog(_ text: String) {
+        guard self.debug else { return }
+        
+        print("[RateMe]: \(text)")
+    }
+    
+}
+
+extension String {
+    func localized(bundle: Bundle) -> String {
+        return bundle.localizedString(forKey: self, value: "", table: "SRLocalizable")
+    }
+}

--- a/RaceSync/Tools/RateMe/RateMeConstants.swift
+++ b/RaceSync/Tools/RateMe/RateMeConstants.swift
@@ -1,0 +1,26 @@
+//
+//  RateMeConstants.swift
+//  RaceSync
+//
+//  Created by Ignacio Romero Zurbuchen on 2020-03-23.
+//  Copyright © 2020 MultiGP Inc. All rights reserved.
+//
+//  Adaptation of SwiftlyRater
+//  Created by Gianluca Di Maggio on 1/7/17.
+//  Copyright © 2017 dima. All rights reserved.
+//
+
+import Foundation
+
+struct RateMeConstants {
+    static let usesUntilPrompt         = 10
+    static let daysUntilPrompt         = 5
+    static let eventsUntilPrompt       = 10
+    static let daysBeforeReminding     = 2
+
+    static let rateButtonTitle         = "Rate Now"
+    static let remindButtonTitle       = "Maybe Later"
+    static let neverRemindButtonTitle  = "No Thanks"
+    static let reviewTitle             = "Rate %@"
+    static let reviewMessage           = "Enjoying the app? Please take a moment to leave a five-star review on the AppStore! Your support is very much appreciated!"
+}

--- a/RaceSync/Tools/RateMe/RateMeDefaults.swift
+++ b/RaceSync/Tools/RateMe/RateMeDefaults.swift
@@ -1,0 +1,121 @@
+//
+//  RateMeDefaults.swift
+//  RaceSync
+//
+//  Created by Ignacio Romero Zurbuchen on 2020-03-23.
+//  Copyright © 2020 MultiGP Inc. All rights reserved.
+//
+//  Adaptation of SwiftlyRater
+//  Created by Gianluca Di Maggio on 1/5/17.
+//  Copyright © 2017 dima. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Int User Defaults
+
+protocol IntUserDefaultable {
+    associatedtype StateDefaultKey: RawRepresentable
+}
+
+extension IntUserDefaultable where StateDefaultKey.RawValue == String {
+    static func set(_ value: Int, forKey key: StateDefaultKey) {
+        let key = key.rawValue
+        UserDefaults.standard.set(value, forKey: key)
+    }
+
+    static func int(forKey key: StateDefaultKey) -> Int {
+        let key = key.rawValue
+        return UserDefaults.standard.integer(forKey: key)
+    }
+}
+
+// MARK: - Bool User Defaults
+
+protocol BoolUserDefaultable {
+    associatedtype StateDefaultKey: RawRepresentable
+}
+
+extension BoolUserDefaultable where StateDefaultKey.RawValue == String {
+    static func set(_ value: Bool, forKey key: StateDefaultKey) {
+        let key = key.rawValue
+        UserDefaults.standard.set(value, forKey: key)
+    }
+
+    static func bool(forKey key: StateDefaultKey) -> Bool {
+        let key = key.rawValue
+        return UserDefaults.standard.bool(forKey: key)
+    }
+}
+
+// MARK: - Object User Defaults
+
+protocol ObjectUserDefaultable {
+    associatedtype StateDefaultKey: RawRepresentable
+}
+
+extension ObjectUserDefaultable where StateDefaultKey.RawValue == String {
+    static func set(_ value: Any?, forKey key: StateDefaultKey) {
+        let key = key.rawValue
+        UserDefaults.standard.set(value, forKey: key)
+    }
+}
+
+// MARK: - String User Defaults
+
+protocol StringUserDefaultable {
+    associatedtype StateDefaultKey: RawRepresentable
+}
+
+extension StringUserDefaultable where StateDefaultKey.RawValue == String {
+    static func set(_ value: String, forKey key: StateDefaultKey) {
+        let key = key.rawValue
+        UserDefaults.standard.set(value, forKey: key)
+    }
+
+    static func string(forKey key: StateDefaultKey) -> String? {
+        let key = key.rawValue
+        return UserDefaults.standard.string(forKey: key)
+    }
+}
+
+// MARK: - Date User Defaults
+
+protocol DateUserDefaultable {
+    associatedtype StateDefaultKey: RawRepresentable
+}
+
+extension DateUserDefaultable where StateDefaultKey.RawValue == String {
+    static func date(forKey key: StateDefaultKey) -> Date? {
+        let key = key.rawValue
+
+        guard let dateTimestamp = UserDefaults.standard.object(forKey: key) as? Double else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: dateTimestamp)
+    }
+}
+
+extension UserDefaults {
+
+    struct RateMeDefaults: IntUserDefaultable, BoolUserDefaultable, ObjectUserDefaultable, StringUserDefaultable, DateUserDefaultable {
+
+        enum StateDefaultKey: String {
+            case firstUse
+            case lastReminded
+            case usesCount
+            case eventsCount
+            case declinedToRate
+            case versionRated
+            case lastVersionUsed
+        }
+
+        var keyValue: String {
+            return "com.multigp.RaceSync.rateme.\(self)"
+        }
+
+        static func synchronize() {
+            UserDefaults.standard.synchronize()
+        }
+    }
+}

--- a/RaceSync/UI Components/Joinable.swift
+++ b/RaceSync/UI Components/Joinable.swift
@@ -105,6 +105,8 @@ extension Joinable {
                 if state != newState {
                     race.isJoined = false
                     button.joinState = newState
+
+                    RateMe.sharedInstance.userDidPerformEvent(showPrompt: true)
                 }
 
                 button.isLoading = false
@@ -116,6 +118,8 @@ extension Joinable {
                 if state != newState {
                     race.isJoined = true
                     button.joinState = newState
+
+                    RateMe.sharedInstance.userDidPerformEvent(showPrompt: true)
                 }
 
                 button.isLoading = false

--- a/RaceSync/View Controllers/Aircrafts/AircraftDetailViewController.swift
+++ b/RaceSync/View Controllers/Aircrafts/AircraftDetailViewController.swift
@@ -280,10 +280,7 @@ extension AircraftDetailViewController: FormViewControllerDelegate {
             guard let strongSelf = self else { return }
             if status {
                 let updatedAircraft = strongSelf.updateAircraft(aircraft, withItem: item, forRow: AircraftRow.name)
-                strongSelf.aircraftViewModel = AircraftViewModel(with: updatedAircraft)
-                strongSelf.tableView.reloadData()
-                strongSelf.delegate?.aircraftDetailViewController(strongSelf, didEditAircraft: aircraft.id)
-                viewController.dismiss(animated: true, completion: nil)
+                strongSelf.handleAircraftUpdate(updatedAircraft, from: viewController)
             } else if let error = error {
                 viewController.isLoading = false
                 AlertUtil.presentAlertMessage(error.localizedDescription, title: "Error")
@@ -326,10 +323,7 @@ extension AircraftDetailViewController: FormViewControllerDelegate {
             guard let strongSelf = self else { return }
             if status {
                 let updatedAircraft = strongSelf.updateAircraft(aircraft, withItem: item, forRow: row)
-                strongSelf.aircraftViewModel = AircraftViewModel(with: updatedAircraft)
-                strongSelf.tableView.reloadData()
-                strongSelf.delegate?.aircraftDetailViewController(strongSelf, didEditAircraft: updatedAircraft.id)
-                viewController.dismiss(animated: true, completion: nil)
+                strongSelf.handleAircraftUpdate(updatedAircraft, from: viewController)
             }  else if let error = error {
                 viewController.isLoading = false
                 AlertUtil.presentAlertMessage(error.localizedDescription, title: "Error")
@@ -370,6 +364,15 @@ extension AircraftDetailViewController: FormViewControllerDelegate {
             break
         }
         return aircraft
+    }
+
+    func handleAircraftUpdate(_ aircraft: Aircraft, from viewController: UIViewController) {
+        aircraftViewModel = AircraftViewModel(with: aircraft)
+        tableView.reloadData()
+        delegate?.aircraftDetailViewController(self, didEditAircraft: aircraft.id)
+        viewController.dismiss(animated: true, completion: nil)
+
+        RateMe.sharedInstance.userDidPerformEvent(showPrompt: true)
     }
 }
 

--- a/RaceSync/View Controllers/Aircrafts/NewAircraftViewController.swift
+++ b/RaceSync/View Controllers/Aircrafts/NewAircraftViewController.swift
@@ -187,6 +187,8 @@ class NewAircraftViewController: ViewController {
             guard let strongSelf = self else { return }
             if let aircraft = aircraft {
                 strongSelf.delegate?.newAircraftViewController(strongSelf, didCreateAircraft: aircraft)
+
+                RateMe.sharedInstance.userDidPerformEvent(showPrompt: true)
             } else if let error = error {
                 AlertUtil.presentAlertMessage(error.localizedDescription, title: "Error")
             }

--- a/RaceSync/View Controllers/Races/ForceJoinViewController.swift
+++ b/RaceSync/View Controllers/Races/ForceJoinViewController.swift
@@ -73,6 +73,7 @@ class ForceJoinViewController: ViewController, Shimmable {
 
     fileprivate enum Constants {
         static let padding: CGFloat = UniversalConstants.padding
+        static let joinButtonTitle: String = "Force Join"
     }
 
     // MARK: - Initialization
@@ -148,9 +149,11 @@ class ForceJoinViewController: ViewController, Shimmable {
 
                     if state != newState {
                         button.joinState = newState
-                        button.setTitle("Force Join", for: .normal)
+                        button.setTitle(Constants.joinButtonTitle, for: .normal)
                         self.joinedIds = self.joinedIds.filter { $0 != userId }
                         self.didForceJoin = true
+
+                        RateMe.sharedInstance.userDidPerformEvent(showPrompt: true)
                     }
                 }
             }) { (action) in
@@ -165,6 +168,8 @@ class ForceJoinViewController: ViewController, Shimmable {
                         button.joinState = newState
                         self.joinedIds += [userId]
                         self.didForceJoin = true
+
+                        RateMe.sharedInstance.userDidPerformEvent(showPrompt: true)
                     }
                 }
             }) { (action) in
@@ -310,7 +315,7 @@ extension ForceJoinViewController: UITableViewDataSource {
             cell.joinButton.joinState = .joined
         } else {
             cell.joinButton.joinState = .join
-            cell.joinButton.setTitle("Force Join", for: .normal)
+            cell.joinButton.setTitle(Constants.joinButtonTitle, for: .normal)
         }
 
         return cell


### PR DESCRIPTION
Closes #8 

Implementing App Store Rating management, triggered after key events such as:
- joining/resigning a race
- adding/editing an aircraft
- force-joining/resigning a user to a race.

How the prompt looks like:
![image](https://user-images.githubusercontent.com/590579/77359044-397ed200-6d08-11ea-815e-15f8207b332e.png)

After tapping on "Rate Now", the app opens the App Store and directs the user straight to the ratings and reviews section:
![IMG_D2E00DD9BF5E-1](https://user-images.githubusercontent.com/590579/77359094-4d2a3880-6d08-11ea-9e22-196be53314eb.jpeg)
