### PR TITLE
videoRxChannels is required for aircraft creation

### DIFF
--- a/RaceSync/View Controllers/Aircrafts/AircraftForm.swift
+++ b/RaceSync/View Controllers/Aircrafts/AircraftForm.swift
@@ -82,7 +82,7 @@ extension AircraftRow {
 
     var isAircraftSpecRequired: Bool {
         switch self {
-        case .name, .videoTx, .videoTxChannels, .antenna:
+        case .name, .videoTx, .videoTxChannels, .videoRxChannels, .antenna:
             return true
         default:
             return false


### PR DESCRIPTION
LundyFPV pointed this out that in the iOS app when an aircraft is created without videoRxChannels specified it appears not to assign that pilotId a channel when the race schedule is generated. 